### PR TITLE
Adjusted elements positioning in CTA section

### DIFF
--- a/Components/Cta.jsx
+++ b/Components/Cta.jsx
@@ -7,7 +7,7 @@ import { slideInLeft } from "@/Constant";
 const Cta = () => {
   return (
     <section className=" px-3 py-20 md:p-20 my-16 lg:p-36 relative">
-      <figure className=" max-w-[15%] ring-1 ring-slate-300 absolute left-0 top-1/3 aspect-square rounded-full p-1">
+      <figure className=" max-w-[15%] ring-1 ring-slate-300 absolute left-6 top-1/3 aspect-square rounded-full p-1">
         <Image
           src="/icons/black.svg"
           width={70}
@@ -16,6 +16,7 @@ const Cta = () => {
           className=" aspect-square rounded-full object-cover w-full"
         />
       </figure>
+
       <figure className=" max-w-[15%] absolute bottom-0 lg:bottom-6  right-1/5 aspect-square rounded-full p-1 ring-1 ring-slate-300">
         <Image
           src="/icons/african.svg"
@@ -25,6 +26,7 @@ const Cta = () => {
           className=" aspect-square rounded-full object-cover w-full"
         />
       </figure>
+
       <figure className=" absolute -top-2 left-1/5 aspect-square rounded-full max-w-[15%] ring-1 ring-slate-200">
         <Image
           src="/icons/curl.svg"
@@ -34,7 +36,8 @@ const Cta = () => {
           className=" object-cover w-full "
         />
       </figure>
-      <figure className=" max-w-[15%] ring-1 ring-slate-300 absolute right-0 bottom-1/4 aspect-square rounded-full p-1">
+
+      <figure className=" max-w-[15%] ring-1 ring-slate-300 absolute right-6 bottom-1/4 aspect-square rounded-full p-1">
         <Image
           src="/icons/afro.svg"
           width={70}
@@ -43,6 +46,7 @@ const Cta = () => {
           className=" aspect-square rounded-full object-cover w-full"
         />
       </figure>
+
       <figure className=" absolute right-1/10 top-1 aspect-square rounded-full p-1 ring-1 ring-slate-200 max-w-[15%]">
         <Image
           src="/icons/fcurls.svg"
@@ -52,6 +56,7 @@ const Cta = () => {
           className=" aspect-square rounded-full object-cover w-full"
         />
       </figure>
+
       <figure className=" max-w-[15%] ring-1 ring-slate-300 absolute bottom-0 left-1/10 aspect-square rounded-full p-1 z-0">
         <Image
           src="/icons/hd.svg"


### PR DESCRIPTION
- Reposition floating avatar icons for better visual balance:
  - Left avatar moved from left-0 to left-6
  - Right avatar moved from right-0 to right-6